### PR TITLE
Incorrect file icon theme name to activate icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,5 +140,5 @@ Here is Angular work directory preview :
 
 ## How to use
 
-After installation and activation, you should go in settings (`File` → `Preferences` on Windows, or `Code` → `Preferences` on OSX), choose `File Icon Theme`, and select `VSCode Great Icons`.
+After installation and activation, you should go in settings (`File` → `Preferences` on Windows, or `Code` → `Preferences` on OSX), choose `File Icon Theme`, and select `VSCode Simpler Icons`.
 


### PR DESCRIPTION
Updated to `VSCode Simpler Icons` from `VSCode Great Icons`